### PR TITLE
Add missing dependency to gcalert

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          pacman -Sy --noconfirm --noprogressbar base-devel git
+          pacman -S --noconfirm --noprogressbar base-devel git
           echo 'nobody ALL=NOPASSWD:ALL' >> /etc/sudoers
           chown -R nobody /vol/$PACKAGE && cd /vol/$PACKAGE
           sudo -u nobody makepkg -sri --noconfirm --noprogressbar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          pacman -S --noconfirm --noprogressbar base-devel git
+          pacman -Sy --noconfirm --noprogressbar base-devel git
           echo 'nobody ALL=NOPASSWD:ALL' >> /etc/sudoers
           chown -R nobody /vol/$PACKAGE && cd /vol/$PACKAGE
           sudo -u nobody makepkg -sri --noconfirm --noprogressbar

--- a/gcalert/.SRCINFO
+++ b/gcalert/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gcalert
 	pkgdesc = Lightweight Google Calendar notifications
 	pkgver = 3.2
-	pkgrel = 5
+	pkgrel = 6
 	url = https://github.com/codehearts/gcalert
 	arch = any
 	license = GPL
@@ -10,6 +10,7 @@ pkgbase = gcalert
 	depends = python-google-api-python-client
 	depends = python-notify2
 	depends = python-dateutil
+	depends = python-oauth2client
 	source = gcalert-3.2::https://raw.githubusercontent.com/codehearts/gcalert/v3.2/gcalert
 	sha256sums = 81ea48b99cbe0baa40295114ecf7c5c6a7acc4eeb774cc28ae4579f5bb70dd02
 

--- a/gcalert/PKGBUILD
+++ b/gcalert/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=gcalert
 pkgver=3.2
-pkgrel=5
+pkgrel=6
 pkgdesc='Lightweight Google Calendar notifications'
 arch=('any')
 url=https://github.com/codehearts/gcalert
 license=('GPL')
-depends=('python' 'libnotify' 'python-google-api-python-client' 'python-notify2' 'python-dateutil')
+depends=('python' 'libnotify' 'python-google-api-python-client' 'python-notify2' 'python-dateutil' 'python-oauth2client')
 source=("$pkgname-$pkgver::https://raw.githubusercontent.com/codehearts/gcalert/v$pkgver/gcalert")
 sha256sums=('81ea48b99cbe0baa40295114ecf7c5c6a7acc4eeb774cc28ae4579f5bb70dd02')
 


### PR DESCRIPTION
`python-oauth2client` was missing and has been added